### PR TITLE
Create path before saving training data to disk

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Create an empty file called `train_data_config.json`, copy-paste the following t
   "split": 0.9,
   "tilt_axis": "Y",
   "n_normalization_samples": 500,
-  "path": "./"
+  "path": "./",
+  "overwrite": false
 }
 ```
 #### Parameters:

--- a/cryocare/scripts/cryoCARE_extract_train_data.py
+++ b/cryocare/scripts/cryoCARE_extract_train_data.py
@@ -2,6 +2,7 @@
 import argparse
 import json
 import warnings
+import os
 from cryocare.internals.CryoCAREDataModule import CryoCARE_DataModule
 
 

--- a/cryocare/scripts/cryoCARE_extract_train_data.py
+++ b/cryocare/scripts/cryoCARE_extract_train_data.py
@@ -25,6 +25,7 @@ def main():
     dm.setup(config['odd'], config['even'], n_samples_per_tomo=config['num_slices'],
                              validation_fraction=(1.0 - config['split']), sample_shape=config['patch_shape'],
                              tilt_axis=config['tilt_axis'], n_normalization_samples=config['n_normalization_samples'])
+    os.makedirs(config['path'],exist_ok=True)
     dm.save(config['path'])
 
 

--- a/cryocare/scripts/cryoCARE_extract_train_data.py
+++ b/cryocare/scripts/cryoCARE_extract_train_data.py
@@ -3,6 +3,7 @@ import argparse
 import json
 import warnings
 import os
+import sys
 from cryocare.internals.CryoCAREDataModule import CryoCARE_DataModule
 
 
@@ -26,7 +27,16 @@ def main():
     dm.setup(config['odd'], config['even'], n_samples_per_tomo=config['num_slices'],
                              validation_fraction=(1.0 - config['split']), sample_shape=config['patch_shape'],
                              tilt_axis=config['tilt_axis'], n_normalization_samples=config['n_normalization_samples'])
-    os.makedirs(config['path'],exist_ok=True)
+    
+    try:
+        os.makedirs(config['output'])
+    except OSError:
+        if 'overwrite' in config and config['overwrite']:
+            os.makedirs(config['output'], exist_ok=True)
+        else:
+            print("Output directory already exists. Please choose a new output directory or set 'overwrite' to 'true' in your configuration file.")
+            sys.exit(1)
+            
     dm.save(config['path'])
 
 

--- a/cryocare/scripts/cryoCARE_extract_train_data.py
+++ b/cryocare/scripts/cryoCARE_extract_train_data.py
@@ -29,10 +29,10 @@ def main():
                              tilt_axis=config['tilt_axis'], n_normalization_samples=config['n_normalization_samples'])
     
     try:
-        os.makedirs(config['output'])
+        os.makedirs(config['path'])
     except OSError:
         if 'overwrite' in config and config['overwrite']:
-            os.makedirs(config['output'], exist_ok=True)
+            os.makedirs(config['path'], exist_ok=True)
         else:
             print("Output directory already exists. Please choose a new output directory or set 'overwrite' to 'true' in your configuration file.")
             sys.exit(1)


### PR DESCRIPTION
The folder `config['path']` should be created before saving training data to disk. Otherwise it will crash.