### PR TITLE
Added GPU ID selection capability

### DIFF
--- a/cryocare/scripts/cryoCARE_train.py
+++ b/cryocare/scripts/cryoCARE_train.py
@@ -6,6 +6,7 @@ from csbdeep.models import Config
 import pickle
 from os.path import join
 from cryocare.internals.CryoCAREDataModule import CryoCARE_DataModule
+from cryocare.scripts.cryoCARE_predict import set_gpu_id
 
 def main():
     parser = argparse.ArgumentParser(description='Load training config.')
@@ -15,6 +16,8 @@ def main():
     with open(args.conf, 'r') as f:
         config = json.load(f)
 
+    set_gpu_id(config)
+    
     dm = CryoCARE_DataModule()
     dm.load(config['train_data'])
 


### PR DESCRIPTION
Hi,
I've added a few lines to allow the user to select GPU IDs in train.py and predict.py. The user specifies GPU IDs as a list or an integer in the json config files for those scripts. Importantly, I've also added a line to set_memory_growth to true for GPUs as without it I was consistently getting OOM errors if you think this is a sensible way to deal with that? The structure of this PR could probably do with some work too: I wasn't sure exactly where to place the function and how to call it within the current cryoCARE structure so I simply added a function in predict.py and also call it in train.py
Thanks,
Euan