### PR TITLE
np.bool is depreciated in latest numpy version, this prevents error

### DIFF
--- a/cryocare/internals/CryoCARE.py
+++ b/cryocare/internals/CryoCARE.py
@@ -171,7 +171,7 @@ class CryoCARE(CARE):
         # _permute_axes_n_tiles: (img_axes_in <-> net_axes_in) to convert n_tiles between img and net axes
         def _permute_n_tiles(n, undo=False):
             # hack: move tiling axis around in the same way as the image was permuted by creating an array
-            return _permute_axes_n_tiles(np.empty(n, np.bool), undo=undo).shape
+            return _permute_axes_n_tiles(np.empty(n, np.bool_), undo=undo).shape
 
         # to support old api: set scalar n_tiles value for the largest tiling axis
         if np.isscalar(n_tiles) and int(n_tiles) == n_tiles and 1 <= n_tiles:


### PR DESCRIPTION
Tiny boring fix :) Latest version of numpy (v1.24) the line np.bool fails as this is depreciated now. The change allows it to work in both v1.24 and older versions. 