### PR TITLE
set numpy version compatible with 1.19.2 to fix installation issue

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ],
     python_requires='>=3.8',
     install_requires=[
-        "numpy",
+        "numpy~=1.19.2",
         "mrcfile",
         "csbdeep>=0.7.0,<0.8.0",
         "psutil"


### PR DESCRIPTION
Hi cryocare devs!

Ran into the same problem as issue #47. I updated the setup.py to conform with tensorflow 2.4.0 depending on compatibility with numpy 19.2.0.
Made this PR in case you want to include this fix to the setup script.