### PR TITLE
Implementation of Masked Extraction (Issue #54)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,9 @@ Create an empty file called `train_data_config.json`, copy-paste the following t
   "odd": [
     "/path/to/odd.rec"
   ],
+  "mask": [
+    "/path/to/mask.mrc or None"
+  ],
   "patch_shape": [
     72,
     72,
@@ -78,6 +81,7 @@ Create an empty file called `train_data_config.json`, copy-paste the following t
 #### Parameters:
 * `"even"`: List of all even tomograms.
 * `"odd"`: List of all odd tomograms. Note the order has to be the same as in `"even"`.
+* `"mask"`: If desired, a list of binary masks to limit where subvolumes are extracted, similar to IsoNet. If you want to skip masking, put `"None"`. Order has to be the same as in `even`.
 * `"patch_shape"`: Size of the sub-volumes used for training. Should not be smaller than `64, 64, 64`.
 * `"num_slices"`: Number of sub-volumes extracted per tomograms. 
 * `"tilt_axis"`: Tilt-axis of the tomograms. We split the tomogram along this axis to extract train- and validation data separately.

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Create an empty file called `train_data_config.json`, copy-paste the following t
     "/path/to/odd.rec"
   ],
   "mask": [
-    "/path/to/mask.mrc or None"
+    "/path/to/mask.mrc"
   ],
   "patch_shape": [
     72,
@@ -81,7 +81,7 @@ Create an empty file called `train_data_config.json`, copy-paste the following t
 #### Parameters:
 * `"even"`: List of all even tomograms.
 * `"odd"`: List of all odd tomograms. Note the order has to be the same as in `"even"`.
-* `"mask"`: If desired, a list of binary masks to limit where subvolumes are extracted, similar to IsoNet. If you want to skip masking, put `"None"`. Order has to be the same as in `even`.
+* `"mask"`: If desired, a list of binary masks to limit where subvolumes are extracted, similar to IsoNet. Can be left out to skip masking.
 * `"patch_shape"`: Size of the sub-volumes used for training. Should not be smaller than `64, 64, 64`.
 * `"num_slices"`: Number of sub-volumes extracted per tomograms. 
 * `"tilt_axis"`: Tilt-axis of the tomograms. We split the tomogram along this axis to extract train- and validation data separately.

--- a/cryocare/internals/CryoCAREDataModule.py
+++ b/cryocare/internals/CryoCAREDataModule.py
@@ -37,12 +37,8 @@ class CryoCARE_Dataset(tf.keras.utils.Sequence):
         self.tomos_even = [mrcfile.mmap(p, mode='r', permissive=True) for p in self.tomo_paths_even]
         self.n_tomos = len(self.tomo_paths_odd)
 
-        if mask_paths is not None:
-            self.masks = [mrcfile.mmap(p, mode='r', permissive=True) for p in self.mask_paths]
-        else:
-            self.masks = [None] * self.n_tomos
+        if self.mask_paths is None:
             self.mask_paths = [None] * self.n_tomos
-        
 
         self.create_coordinate_lists()
         self.length = sum([c.shape[0] for c in self.coords])
@@ -220,7 +216,7 @@ class CryoCARE_DataModule(object):
         self.train_dataset = None
         self.val_dataset = None
 
-    def setup(self, tomo_paths_odd, tomo_paths_even, mask_paths, n_samples_per_tomo, validation_fraction=0.1,
+    def setup(self, tomo_paths_odd, tomo_paths_even, mask_paths = None, n_samples_per_tomo = 1200, validation_fraction=0.1,
               sample_shape=(64, 64, 64), tilt_axis='Y', n_normalization_samples=500):
         train_extraction_shapes = []
         val_extraction_shapes = []

--- a/cryocare/internals/CryoCAREDataModule.py
+++ b/cryocare/internals/CryoCAREDataModule.py
@@ -3,17 +3,17 @@ import tensorflow as tf
 
 import mrcfile
 import tqdm
-import numpy as np
 
 from os.path import join
 
 
 class CryoCARE_Dataset(tf.keras.utils.Sequence):
-    def __init__(self, tomo_paths_odd=None, tomo_paths_even=None, n_samples_per_tomo=None,
-                 extraction_shapes=None, mean=None, std=None,
+    def __init__(self, tomo_paths_odd=None, tomo_paths_even=None, mask_paths=None,
+                 n_samples_per_tomo=None, extraction_shapes=None, mean=None, std=None,
                  sample_shape=(64, 64, 64), shuffle=True, n_normalization_samples=500, tilt_axis=None):
         self.tomo_paths_odd = tomo_paths_odd
         self.tomo_paths_even = tomo_paths_even
+        self.mask_paths = mask_paths
         self.n_samples_per_tomo = n_samples_per_tomo
         self.tilt_axis = tilt_axis
 
@@ -36,6 +36,13 @@ class CryoCARE_Dataset(tf.keras.utils.Sequence):
         self.tomos_odd = [mrcfile.mmap(p, mode='r', permissive=True) for p in self.tomo_paths_odd]
         self.tomos_even = [mrcfile.mmap(p, mode='r', permissive=True) for p in self.tomo_paths_even]
         self.n_tomos = len(self.tomo_paths_odd)
+
+        if mask_paths is not None:
+            self.masks = [mrcfile.mmap(p, mode='r', permissive=True) for p in self.mask_paths]
+        else:
+            self.masks = [None] * self.n_tomos
+            self.mask_paths = [None] * self.n_tomos
+        
 
         self.create_coordinate_lists()
         self.length = sum([c.shape[0] for c in self.coords])
@@ -103,17 +110,28 @@ class CryoCARE_Dataset(tf.keras.utils.Sequence):
 
     def create_coordinate_lists(self):
         self.coords = []
-        for odd, even, es in zip(self.tomo_paths_odd, self.tomo_paths_even, self.extraction_shapes):
-            self.coords.append(self.__create_coords_for_tomo__(even, odd, es))
+        
+        for odd, even, es, maskfile in zip(self.tomo_paths_odd, self.tomo_paths_even, self.extraction_shapes, self.mask_paths):
+            self.coords.append(self.__create_coords_for_tomo__(even, odd, es, maskfile))
 
         self.coords = np.array(self.coords)
 
-    def __create_coords_for_tomo__(self, even_path, odd_path, extraction_shape):
+    def __create_coords_for_tomo__(self, even_path, odd_path, extraction_shape, mask_path):
         even = mrcfile.mmap(even_path, mode='r')
         odd = mrcfile.mmap(odd_path, mode='r')
-
+        
         assert even.data.shape == odd.data.shape, '{} and {} tomogram have different shapes.'.format(even_path,
                                                                                                      odd_path)
+        
+        # If no mask is specified, just create a one-mask
+        if mask_path is None:
+            mask = np.ones(even.data.shape).astype(np.bool)
+        else:
+            mask = mrcfile.read(mask_path).astype(np.bool)
+
+            assert even.data.shape == mask.data.shape, '{} and {} tomogram / mask have different shapes.'.format(even_path,
+                                                                                                                 mask_path)
+        
         assert even.data.shape[0] > 2 * self.sample_shape[0]
         assert even.data.shape[1] > 2 * self.sample_shape[1]
         assert even.data.shape[2] > 2 * self.sample_shape[2]
@@ -121,6 +139,7 @@ class CryoCARE_Dataset(tf.keras.utils.Sequence):
         coords = self.create_random_coords(extraction_shape[0],
                                            extraction_shape[1],
                                            extraction_shape[2],
+                                           mask,
                                            n_samples=self.n_samples_per_tomo)
 
         even.close()
@@ -128,12 +147,27 @@ class CryoCARE_Dataset(tf.keras.utils.Sequence):
 
         return coords
 
-    def create_random_coords(self, z, y, x, n_samples):
-        z_coords = np.random.randint(z[0], z[1] - self.sample_shape[0], size=n_samples)
-        y_coords = np.random.randint(y[0], y[1] - self.sample_shape[0], size=n_samples)
-        x_coords = np.random.randint(x[0], x[1] - self.sample_shape[0], size=n_samples)
+    def create_random_coords(self, z, y, x, mask, n_samples):
+        # Inspired by isonet preprocessing.cubes:create_cube_seeds()
+        
+        # Get permissible locations based on extraction_shape and sample_shape
+        slices = tuple([slice(z[0],z[1]-self.sample_shape[2]),
+                       slice(y[0],y[1]-self.sample_shape[1]),
+                       slice(x[0],x[1]-self.sample_shape[0])])
+        
+        # Get intersect with mask-allowed values                       
+        valid_inds = np.where(mask[slices])
+        
+        valid_inds = [v + s.start for s, v in zip(slices, valid_inds)]
+        
+        sample_inds = np.random.choice(len(valid_inds[0]),
+                                       n_samples,
+                                       replace=len(valid_inds[0]) < n_samples)
+        
+        rand_inds = [v[sample_inds] for v in valid_inds]
+        
 
-        return np.stack([z_coords, y_coords, x_coords], -1)
+        return np.stack([rand_inds[0],rand_inds[1], rand_inds[2]], -1)
 
     def augment(self, x, y):
         if self.tilt_axis is not None:
@@ -186,7 +220,7 @@ class CryoCARE_DataModule(object):
         self.train_dataset = None
         self.val_dataset = None
 
-    def setup(self, tomo_paths_odd, tomo_paths_even, n_samples_per_tomo, validation_fraction=0.1,
+    def setup(self, tomo_paths_odd, tomo_paths_even, mask_paths, n_samples_per_tomo, validation_fraction=0.1,
               sample_shape=(64, 64, 64), tilt_axis='Y', n_normalization_samples=500):
         train_extraction_shapes = []
         val_extraction_shapes = []
@@ -199,6 +233,7 @@ class CryoCARE_DataModule(object):
 
         self.train_dataset = CryoCARE_Dataset(tomo_paths_odd=tomo_paths_odd,
                                               tomo_paths_even=tomo_paths_even,
+                                              mask_paths=mask_paths,
                                               mean=None,
                                               std=None,
                                               n_samples_per_tomo=int(
@@ -210,6 +245,7 @@ class CryoCARE_DataModule(object):
 
         self.val_dataset = CryoCARE_Dataset(tomo_paths_odd=tomo_paths_odd,
                                             tomo_paths_even=tomo_paths_even,
+                                            mask_paths=mask_paths,
                                             mean=self.train_dataset.mean,
                                             std=self.train_dataset.std,
                                             n_samples_per_tomo=int(n_samples_per_tomo * validation_fraction),

--- a/cryocare/scripts/cryoCARE_extract_train_data.py
+++ b/cryocare/scripts/cryoCARE_extract_train_data.py
@@ -24,7 +24,7 @@ def main():
         config = json.load(f)
 
     dm = CryoCARE_DataModule()
-    dm.setup(config['odd'], config['even'], n_samples_per_tomo=config['num_slices'],
+    dm.setup(config['odd'], config['even'], config['mask'], n_samples_per_tomo=config['num_slices'],
                              validation_fraction=(1.0 - config['split']), sample_shape=config['patch_shape'],
                              tilt_axis=config['tilt_axis'], n_normalization_samples=config['n_normalization_samples'])
     

--- a/cryocare/scripts/cryoCARE_extract_train_data.py
+++ b/cryocare/scripts/cryoCARE_extract_train_data.py
@@ -24,7 +24,7 @@ def main():
         config = json.load(f)
 
     dm = CryoCARE_DataModule()
-    dm.setup(config['odd'], config['even'], config['mask'], n_samples_per_tomo=config['num_slices'],
+    dm.setup(config['odd'], config['even'], mask_paths=[config['mask'] if 'mask' in config else None], n_samples_per_tomo=config['num_slices'],
                              validation_fraction=(1.0 - config['split']), sample_shape=config['patch_shape'],
                              tilt_axis=config['tilt_axis'], n_normalization_samples=config['n_normalization_samples'])
     

--- a/train_data_config.json
+++ b/train_data_config.json
@@ -6,7 +6,7 @@
     "/path/to/odd.rec"
   ],
   "mask": [
-    "/path/to/mask.mrc or None"
+    "/path/to/mask.mrc"
   ],
   "patch_shape": [
     72,

--- a/train_data_config.json
+++ b/train_data_config.json
@@ -5,6 +5,9 @@
   "odd": [
     "/path/to/odd.rec"
   ],
+  "mask": [
+    "/path/to/mask.mrc or None"
+  ],
   "patch_shape": [
     72,
     72,


### PR DESCRIPTION
In `train_data_config.json`, a mask for each even/odd pair can now be specified, which will limit the coordinate extraction to regions within the mask. 

### Example: 
- 5 K2 tomograms from EVN/ODD `MotionCor2` frames aligned using `AreTomo` and reconstructed at bin 4 (5.49 A/pix) using imod `tilt` ([tomotools workflow](https://github.com/tomotools/tomotools)). Dimensions: 959 x 927 x 1093.
- Boundary models created in `imod` slicer view, converted to binary masks using [mod2mask](https://github.com/bwmr/mod2mask).
- Binary mask covers only ~25% of total tomogram value
- Extraction, training and prediction with default parameters in `cryoCARE` v0.3 - either `wt` or patched with `masks`
- **Result:** In the xy plane, differences are minimal between either strategy (masked or unmasked), probably because 1200 subtomograms per tomogram at 72 px side length anyways already covers 45% of total voxels. In the xz plane, reconstruction artifacts are much reduced after masked training, so probably there is some advantage:
![cryoCARE-masked-comparison](https://github.com/juglab/cryoCARE_pip/assets/56264458/da68eb3b-ac10-4776-8f39-2776e66b6a06)

### Checks:
- Coordinates for extraction do respect the mask (as extracted from train_data.npz/coords.npy), see histogram of z positions below (masked in blue, unmasked in orange).
- Extraction with patched `cryoCARE_extract_train_data.py` also works if `mask` is not specified in `train_data_config.json`.
![Figure 2023-12-01 110545](https://github.com/juglab/cryoCARE_pip/assets/56264458/f80ef16a-e03c-4c70-a2d0-878102d84739)
