### PR TITLE
Fixed bug in mask-parser

### DIFF
--- a/cryocare/internals/CryoCAREDataModule.py
+++ b/cryocare/internals/CryoCAREDataModule.py
@@ -216,7 +216,7 @@ class CryoCARE_DataModule(object):
         self.train_dataset = None
         self.val_dataset = None
 
-    def setup(self, tomo_paths_odd, tomo_paths_even, mask_paths = None, n_samples_per_tomo = 1200, validation_fraction=0.1,
+    def setup(self, tomo_paths_odd, tomo_paths_even, mask_paths, n_samples_per_tomo = 1200, validation_fraction=0.1,
               sample_shape=(64, 64, 64), tilt_axis='Y', n_normalization_samples=500):
         train_extraction_shapes = []
         val_extraction_shapes = []

--- a/cryocare/scripts/cryoCARE_extract_train_data.py
+++ b/cryocare/scripts/cryoCARE_extract_train_data.py
@@ -24,7 +24,7 @@ def main():
         config = json.load(f)
 
     dm = CryoCARE_DataModule()
-    dm.setup(config['odd'], config['even'], mask_paths=[config['mask'] if 'mask' in config else None], n_samples_per_tomo=config['num_slices'],
+    dm.setup(config['odd'], config['even'], mask_paths=config['mask'] if 'mask' in config else None, n_samples_per_tomo=config['num_slices'],
                              validation_fraction=(1.0 - config['split']), sample_shape=config['patch_shape'],
                              tilt_axis=config['tilt_axis'], n_normalization_samples=config['n_normalization_samples'])
     


### PR DESCRIPTION
Hi, 

I accidentally introduced a bug in the mask-parser in PR #55, which results in the following error when providing a mask during extraction: 

`FileNotFoundError: [Errno 2] No such file or directory: "['lamella01A_ts_004/lamella01A_ts_004_ali_filtered_rec_bin_2_mask.mrc']"`

This pull-request fixes that error. Extraction tested with and without mask. Sorry about introducing it in the first place.

Best,
Benedikt