### PR TITLE
relax strict requirement of numpy version - see also issues #56, #49,…

### DIFF
--- a/cryocare/internals/CryoCAREDataModule.py
+++ b/cryocare/internals/CryoCAREDataModule.py
@@ -121,9 +121,9 @@ class CryoCARE_Dataset(tf.keras.utils.Sequence):
         
         # If no mask is specified, just create a one-mask
         if mask_path is None:
-            mask = np.ones(even.data.shape).astype(np.bool)
+            mask = np.ones(even.data.shape).astype(np.bool_)
         else:
-            mask = mrcfile.read(mask_path).astype(np.bool)
+            mask = mrcfile.read(mask_path).astype(np.bool_)
 
             assert even.data.shape == mask.data.shape, '{} and {} tomogram / mask have different shapes.'.format(even_path,
                                                                                                                  mask_path)

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setuptools.setup(
     ],
     python_requires='>=3.8',
     install_requires=[
-        "numpy~=1.19.2",
+        "numpy>=1.19.2",
         "mrcfile",
         "csbdeep>=0.7.0,<0.8.0",
         "psutil"


### PR DESCRIPTION
relax strict requirement of numpy version - because numpy~=1.19.2 seems too limiting. 
This PR is related to issues #47, #49, #56